### PR TITLE
Message manager will no longer leak

### DIFF
--- a/jcf_lime_juce.h
+++ b/jcf_lime_juce.h
@@ -266,8 +266,8 @@ namespace jcf
 		{
 			save();
             
-            if (MessageManager::getInstanceWithoutCreating())
-            	MessageManager::getInstanceWithoutCreating()->deregisterBroadcastListener(this);
+			if (MessageManager::getInstanceWithoutCreating())
+				MessageManager::getInstanceWithoutCreating()->deregisterBroadcastListener(this);
 		}
 
 		void actionListenerCallback(const String& message) override

--- a/jcf_lime_juce.h
+++ b/jcf_lime_juce.h
@@ -265,7 +265,9 @@ namespace jcf
 		~AppOptions()
 		{
 			save();
-			MessageManager::getInstance()->deregisterBroadcastListener(this);
+            
+            if (MessageManager::getInstanceWithoutCreating())
+            	MessageManager::getInstanceWithoutCreating()->deregisterBroadcastListener(this);
 		}
 
 		void actionListenerCallback(const String& message) override


### PR DESCRIPTION
If an object of AppOptions is destructed after the message manager has been destructed, it would create a new one which wouldn't get deleted properly